### PR TITLE
Termination with notice

### DIFF
--- a/_terms_inner.html
+++ b/_terms_inner.html
@@ -257,7 +257,7 @@ use of PDF Tables at any time by sending a message to <a href=
 refund any outstanding credit to your account if you terminate it
 in this way.</p>
 
-<p><span class="section-number">29A</span> We may terminate your use of PDF Tables by sending you advance notice. We may send the notice by email to the last email you have registered with us. This agreement, and your use of PDF Tables, will end on the 32nd day after we have sent you the notice (counting the day on which the notice was sent as the first day). This means that all unspent credit on your account will be lost unless you spend it within the notice period.</p>
+<p><span class="section-number">29A</span> We may terminate your use of PDF Tables by sending you notice in advance. We may send such a notice by email to the last email you have registered with us. This agreement, and your use of PDF Tables, will end on the 32nd day after we have sent you the notice (counting the day on which the notice was sent as the first day). This means that all unspent credit on your account will be lost unless you spend it within the notice period.</p>
 
 <p><span class="section-number">31</span> There are unfortunately
 circumstances, which we think will be extremely unlikely to

--- a/_terms_inner.html
+++ b/_terms_inner.html
@@ -257,6 +257,8 @@ use of PDF Tables at any time by sending a message to <a href=
 refund any outstanding credit to your account if you terminate it
 in this way.</p>
 
+<p><span class="section-number">29A</span> We may terminate your use of PDF Tables by sending you advance notice. We may send the notice by email to the last email you have registered with us. This agreement, and your use of PDF Tables, will end on the 32nd day after we have sent you the notice (counting the day on which the notice was sent as the first day). This means that all unspent credit on your account will be lost unless you spend it within the notice period.</p>
+
 <p><span class="section-number">31</span> There are unfortunately
 circumstances, which we think will be extremely unlikely to
 occur, where we may have to terminate your access - for example


### PR DESCRIPTION
I've added a new clause 29A for termination with notice. The users then have 31 days in which to spend their credit or they loose it. This is to cover situations where you have to terminate the service because it is uneconomic.

You will need to renumber section numbers.
