### PR TITLE
Change "PDF Tables" to "PDFTables"

### DIFF
--- a/_terms_inner.html
+++ b/_terms_inner.html
@@ -7,8 +7,8 @@
 a company registered in England and Wales (No. 06979284), whose
 registered office is at James House, Stonecross Business Park,
 Yew Tree Way, Warrington, Cheshire, WA3 3JD (“<em>we</em>”,
-“<em>us</em>”, “<em>our</em>”) agrees to your use of the PDF
-Tables service (“PDF Tables”). By using PDF Tables you agree to
+“<em>us</em>”, “<em>our</em>”) agrees to your use of the PDFTables
+service (“PDFTables”). By using PDFTables you agree to
 be bound by these terms.</p>
 
 <p><span class="section-number">2</span> In these terms and
@@ -24,7 +24,7 @@ as follows:</p>
     here.</li>
 
   <li>“<em>content</em>” means files which you upload to or
-    create using PDF Tables</li>
+    create using PDFTables</li>
 
   <li>“<em>intellectual property</em>” means any rights in patents,
     registered and unregistered designs, copyright, databases,
@@ -63,14 +63,14 @@ of this contract or have contractual force.</p>
 <h2 id="commitment-us">Our commitment to you</h2>
 
 <p><span class="section-number">6</span> We will provide access to
-PDF Tables as detailed in <em>the pricing plan</em>, and subject
+PDFTables as detailed in <em>the pricing plan</em>, and subject
 to the limitations (eg. as to file size or number of
 files) contained in that plan.</p>
 
 <p><span class="section-number">7</span> PDFs can be complicated
 files. It is impossible for us to guarantee that the tables
 extracted from a PDF will be accurate. Some PDFs may not work at
-all. While we hope that PDF Tables will work well for you, we
+all. While we hope that PDFTables will work well for you, we
 make no promises as to its functioning.</p>
 
 <p><span class="section-number">8</span> Your use of the service
@@ -86,7 +86,7 @@ guaranteed service level, please contact us to discuss pricing
 and availability.</p>
 
 <p><span class="section-number">10</span> We will not access any
-<em>content</em> which you store on PDF Tables, including your
+<em>content</em> which you store on PDFTables, including your
 contact details, except in order to:</p>
 
 <ul>
@@ -94,11 +94,10 @@ contact details, except in order to:</p>
     administer the services in <em>the pricing plan</em>;</li>
 
   <li><span class="section-number">10.2</span> Improve and maintain
-    PDF Tables or any tools that we supply for use with PDF
-    Tables;</li>
+    PDFTables or any tools that we supply for use with PDFTables;</li>
 
   <li><span class="section-number">10.3</span> Carry out research
-    into the ways in which PDF Tables is used;</li>
+    into the ways in which PDFTables is used;</li>
 
   <li><span class="section-number">10.4</span> Comply with any
     obligation imposed upon us by law; or</li>
@@ -109,14 +108,14 @@ contact details, except in order to:</p>
 
 <p><span class="section-number">11</span> Unless we are prevented
 from doing so by law, we will notify you within 14 days of any
-requests by third parties relating to your use of PDF Tables
+requests by third parties relating to your use of PDFTables
 (such as copyright infringement notices) or of any legal request
 for a third party to have access to your <em>content</em>.</p>
 
 <p><span class="section-number">12</span> We will not inform third
-parties about your use of PDF Tables unless we are required to do
+parties about your use of PDFTables unless we are required to do
 so by law or you have given us permission to do so. We may
-monitor PDF Tables for duplication of activity by you and another
+monitor PDFTables for duplication of activity by you and another
 user or users and offer to help you and them to combine resources
 in order to reduce your costs. We shall not reveal your identity
 or the nature of your activities in these circumstances without
@@ -129,15 +128,15 @@ circumstances.</p>
 
 <h2 id="commitment-you">Your commitment to us</h2>
 
-<p><span class="section-number">14</span> Your access to PDF
-Tables is conditional upon you keeping to the terms of <em>this
+<p><span class="section-number">14</span> Your access to PDFTables
+is conditional upon you keeping to the terms of <em>this
   agreement</em>, including the Acceptable Use Policy.</p>
 
 <p><span class="section-number">15</span> You are solely
-responsible for your own <em>content</em> and your use of PDF
-Tables, and you will compensate us for any losses we suffer as a
-result of hosting that <em>content</em> or your use of PDF
-Tables, such as claims in copyright.</p>
+responsible for your own <em>content</em> and your use of PDFTables,
+and you will compensate us for any losses we suffer as a
+result of hosting that <em>content</em> or your use of PDFTables,
+such as claims in copyright.</p>
 
 <p><span class="section-number">16</span> You will ensure that
 your contact details and email address are kept accurate and up
@@ -160,31 +159,31 @@ address.</p>
 
 <h2 id="aup">Acceptable Use Policy</h2>
 
-<p><span class="section-number">19</span> You will not use PDF
-Tables for any illegal purpose.</p>
+<p><span class="section-number">19</span> You will not use PDFTables
+for any illegal purpose.</p>
 
-<p><span class="section-number">20</span> You will not use PDF
-Tables to annoy, harass or cause a nuisance to anyone.</p>
+<p><span class="section-number">20</span> You will not use PDFTables
+to annoy, harass or cause a nuisance to anyone.</p>
 
 <p><span class="section-number">20</span> You will respect our
 <em>intellectual property</em> rights and the <em>intellectual property</em>
-rights of other users of PDF Tables, and comply with the licence
+rights of other users of PDFTables, and comply with the licence
 requirements of any material that you process, so far as those
 requirements are legally enforceable.</p>
 
 <p><span class="section-number">21</span> You will not attempt to
-breach the security of PDF Tables.</p>
+breach the security of PDFTables.</p>
 
 <p><span class="section-number">22</span> You will report to us
 privately in writing any occurrence, including accidental
 occurrences, which leads to you gaining unauthorised access to
-any part of PDF Tables as soon as is practical after you become
+any part of PDFTables as soon as is practical after you become
 aware that this has happened. In these circumstances you will not
-use PDF Tables to interact with any material which you are not
+use PDFTables to interact with any material which you are not
 authorised to access.</p>
 
-<p><span class="section-number">23</span> You will not use PDF
-Tables to do anything:</p>
+<p><span class="section-number">23</span> You will not use PDFTables
+to do anything:</p>
 
 <ul>
   <li><span class="section-number">23.1</span> which is
@@ -208,10 +207,10 @@ directed).</p>
 
 <p><span class="section-number">24</span> Cookies are short text
 files stored in your web browser to allow us to remember you when
-you return to our websites. When you access PDF Tables by means
+you return to our websites. When you access PDFTables by means
 of a web browser, you consent to our using cookies to personally
 identify you in order to improve your experience of our websites
-and the functioning of PDF Tables. You also consent to the
+and the functioning of PDFTables. You also consent to the
 setting of Cookies by various third party services (see our
 <a href="/cookies">cookie page</a> for details).</p>
 
@@ -244,7 +243,7 @@ other pricing plan and we have announced changes to our terms and
 conditions, you may terminate your contract with us by giving us
 notice in writing within 21 days of the date on which the
 announcement was made. Under these circumstances, your right of
-access to PDF Tables will terminate on the date the new terms and
+access to PDFTables will terminate on the date the new terms and
 conditions come into force. You will not be entitled to a refund
 in respect of any outstanding credit or other money paid to
 us.</p>
@@ -252,15 +251,15 @@ us.</p>
 <h2 id="termination">Termination</h2>
 
 <p><span class="section-number">29</span> You may terminate your
-use of PDF Tables at any time by sending a message to <a href=
+use of PDFTables at any time by sending a message to <a href=
 "mailto:hello@pdftables.com">hello@pdftables.com</a>. We will not
 refund any outstanding credit to your account if you terminate it
 in this way.</p>
 
-<p><span class="section-number">30</span> We may terminate your use of PDF
-Tables by sending you notice in advance. We may send such a notice by email to
-the last email you have registered with us. This agreement, and your use of PDF
-Tables, will end on the 32nd day after we have sent you the notice (counting
+<p><span class="section-number">30</span> We may terminate your use of PDFTables
+by sending you notice in advance. We may send such a notice by email to
+the last email you have registered with us. This agreement, and your use of PDFTables,
+will end on the 32nd day after we have sent you the notice (counting
 the day on which the notice was sent as the first day). This means that all
 unspent credit on your account will be lost unless you spend it within the
 notice period.</p>
@@ -284,10 +283,10 @@ offered if your account is terminated for such a breach.</p>
 
 <h2 id="ip">Intellectual property</h2>
 
-<p><span class="section-number">33</span> Your use of PDF Tables
+<p><span class="section-number">33</span> Your use of PDFTables
 does not grant us any additional <em>intellectual property</em>
 rights in respect of your <em>content</em>, and the act of using
-PDF Tables to process data shall not grant us any additional
+PDFTables to process data shall not grant us any additional
 <em>intellectual property</em> rights over the output of that
 processing.</p>
 


### PR DESCRIPTION
Remove spacing in line with the rest of the site; see
https://github.com/scraperwiki/pdftables.com/pull/1547
